### PR TITLE
Remove npm commands

### DIFF
--- a/marketing-contentful-next/README.md
+++ b/marketing-contentful-next/README.md
@@ -96,8 +96,6 @@ Otherwise, the template content is populated with each build and eventually over
 
 Install all packages first:
 ```bash
-npm install
-# or
 yarn install
 ```
 
@@ -118,19 +116,13 @@ CONTENTFUL_SPACE_DATA_LOCATION=./path/to/your/jsonData.json
 
 Run the development server:
 ```bash
-npm run dev
-# or
 yarn dev
 ```
 
 ### Import and Export Data to Contentful
 
 ```bash
-npm run setup
-# or
 yarn setup
 
-npm run export
-# or
 yarn export
 ```


### PR DESCRIPTION
Although npm v >=7 [supports](https://blog.npmjs.org/post/621733939456933888/npm-v7-series-why-keep-package-lockjson.html) the `yarn.lock` file format, it is not necessarily the best approach. Npm will still create a `package-lock.json` file  and update the existing `yarn.lock` file. 

It is better to make it clear in the documentation that yarn is the package manager of choice for this repository. 