### PR TITLE
Cleaner 'use client' implementation

### DIFF
--- a/marketing-contentful-next-app/components/Banner/Banner.tsx
+++ b/marketing-contentful-next-app/components/Banner/Banner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Link from 'next/link';
 import { XMarkIcon } from '@heroicons/react/24/solid';

--- a/marketing-contentful-next-app/components/Client/ClientExperience.tsx
+++ b/marketing-contentful-next-app/components/Client/ClientExperience.tsx
@@ -1,8 +1,0 @@
-'use client';
-
-import { Experience as NinetailedExperience } from '@ninetailed/experience.js-react';
-
-// eslint-disable-next-line
-export function Experience(props: any) {
-  return <NinetailedExperience {...props} />;
-}

--- a/marketing-contentful-next-app/components/HubspotForm/HubspotForm.tsx
+++ b/marketing-contentful-next-app/components/HubspotForm/HubspotForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useNinetailed, useProfile } from '@ninetailed/experience.js-next';
 import { IHubspotForm } from '@/types/contentful';
 import { useForm, SubmitHandler } from 'react-hook-form';

--- a/marketing-contentful-next-app/components/Navigation/Navigation.tsx
+++ b/marketing-contentful-next-app/components/Navigation/Navigation.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/marketing-contentful-next-app/components/Renderer/BlockRenderer.tsx
+++ b/marketing-contentful-next-app/components/Renderer/BlockRenderer.tsx
@@ -1,22 +1,20 @@
 'use client';
 
 import React from 'react';
-import { Experience } from '@/components/Client/ClientExperience';
+import { Experience } from '@ninetailed/experience.js-react';
 
 import get from 'lodash/get';
 
-import {
-  ClientBanner,
-  ClientCta,
-  ClientHero,
-  ClientHubspotForm,
-  ClientFeature,
-  ClientFooter,
-  ClientNavigation,
-  ClientPricingPlan,
-  ClientPricingTable,
-  ClientSectionsGroup,
-} from '@/components/Client/ClientBlocks';
+import { Banner } from '@/components/Banner';
+import { Cta } from '@/components/Cta';
+import { Feature } from '@/components/Feature';
+import { Footer } from '@/components/Footer';
+import { Hero } from '@/components/Hero';
+import { HubspotForm } from '@/components/HubspotForm';
+import { Navigation } from '@/components/Navigation';
+import { PricingPlan } from '@/components/PricingPlan';
+import { PricingTable } from '@/components/PricingTable';
+import { SectionsGroup } from '@/components/SectionsGroup';
 
 import {
   IBanner,
@@ -34,16 +32,16 @@ import { ComponentContentTypes } from '@/lib/constants';
 import { parseExperiences, singularOrArrayBlock } from '@/lib/experiences';
 
 const ContentTypeMap = {
-  [ComponentContentTypes.Banner]: ClientBanner,
-  [ComponentContentTypes.CTA]: ClientCta,
-  [ComponentContentTypes.Hero]: ClientHero,
-  [ComponentContentTypes.HubspotForm]: ClientHubspotForm,
-  [ComponentContentTypes.Feature]: ClientFeature,
-  [ComponentContentTypes.Footer]: ClientFooter,
-  [ComponentContentTypes.Navigation]: ClientNavigation,
-  [ComponentContentTypes.PricingPlan]: ClientPricingPlan,
-  [ComponentContentTypes.PricingTable]: ClientPricingTable,
-  [ComponentContentTypes.SectionsGroup]: ClientSectionsGroup,
+  [ComponentContentTypes.Banner]: Banner,
+  [ComponentContentTypes.CTA]: Cta,
+  [ComponentContentTypes.Hero]: Hero,
+  [ComponentContentTypes.HubspotForm]: HubspotForm,
+  [ComponentContentTypes.Feature]: Feature,
+  [ComponentContentTypes.Footer]: Footer,
+  [ComponentContentTypes.Navigation]: Navigation,
+  [ComponentContentTypes.PricingPlan]: PricingPlan,
+  [ComponentContentTypes.PricingTable]: PricingTable,
+  [ComponentContentTypes.SectionsGroup]: SectionsGroup,
 };
 
 type Component =


### PR DESCRIPTION
Clean up uneccessary "use client" directives. Many page components and the `<Experience>` component itself did not need the "use client" directive because the parent BlockRenderer.tsx component acts the parent to these components.