### PR TITLE
docs: add AI harness readiness guidance [NT-4002]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Repository purpose
+
+Public collection of example Contentful and Ninetailed applications for several JavaScript frameworks.
+
+## Working rules
+
+- Read README.md and the nearest package or project documentation before changing behavior.
+- Keep changes scoped to the component or example that owns the behavior.
+- Do not commit credentials, tokens, generated secrets, or local environment files.
+- Treat checked-in manifests and lockfiles as the source of truth for tooling.
+- Update documentation when commands, layout, or public behavior changes.
+- Preserve existing generated files and regenerate them only through their owning command.
+- Run the smallest relevant validation first, then the repository-level checks.
+- Call out missing credentials or external services instead of bypassing their checks.
+- Keep public documentation free of private links, credentials, and non-public context.
+- Record durable architectural choices under docs/ADRs/.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Architecture
+
+## Purpose
+
+Public collection of example Contentful and Ninetailed applications for several JavaScript frameworks.
+
+## Main areas
+
+- Each top-level application is an independent example.
+- contentful-nuxt and contentful-vue demonstrate Vue ecosystem integrations.
+- marketing-contentful-next variants demonstrate Next.js integration patterns.
+- Each example owns its local manifest, configuration, and setup instructions.
+
+## Change flow
+
+Repository manifests and checked-in configuration define how source becomes a build, package, report, example, or documentation artifact. Keep changes inside the owning area and follow explicit dependencies rather than copying behavior between components.
+
+## Boundaries
+
+External services, credentials, and deployment environments are not represented by source code alone. Local validation should use documented fixtures or configuration and must not embed secrets.
+
+## Failure and verification
+
+Start with the narrowest affected command, inspect its direct inputs, and expand to repository-level validation. If a required external system is unavailable, record that verification gap instead of claiming success.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Before you start
+
+Read README.md, AGENTS.md, and the configuration nearest to the code or documentation you plan to change. Use the runtime and package manager selected by the repository.
+
+## Setup and validation
+
+- `Follow the README in the selected example.`
+- `Install dependencies inside the selected example directory.`
+- `Run that example's checked-in development or build script.`
+
+Run only commands that apply to the changed component, but do not omit repository-level checks when shared contracts or configuration change.
+
+## Change discipline
+
+Keep commits focused and include generated outputs only when produced by their documented generator. Never commit credentials, local environment files, or service tokens. Preserve public compatibility unless the change explicitly documents a migration.
+
+## Review notes
+
+Describe the affected component, evidence used for behavioral claims, validation performed, and any checks blocked by credentials or external systems. Update README.md, ARCHITECTURE.md, and ADRs when the change alters durable guidance.
+

--- a/docs/ADRs/0001-keep-examples-as-independent-applications.md
+++ b/docs/ADRs/0001-keep-examples-as-independent-applications.md
@@ -1,0 +1,17 @@
+# Keep examples as independent applications
+
+- Status: Accepted
+- Scope: Ninetailed Examples
+
+## Context
+
+Examples target different frameworks and integration styles with dependency requirements that do not necessarily move together.
+
+## Decision
+
+Store examples in one repository while keeping package manifests and runtime setup local to each example.
+
+## Consequences
+
+Do not assume one root install or test command covers the repository; validate only the examples affected by a change.
+


### PR DESCRIPTION
## Summary

- add repository-specific AI harness guidance in `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md`
- record factual architectural decisions under `docs/ADRs/`
- keep this documentation-only: no catalog metadata or Agents Kit consumer was added

## Why

This prepares the repository for the AI Harness governance controls tracked by NT-4002 while preserving its existing runtime and tooling.

## Validation

- governance document thresholds and ADR discovery passed
- referenced paths and whitespace checks passed

Ticket: [NT-4002](https://contentful.atlassian.net/browse/NT-4002)


[NT-4002]: https://contentful.atlassian.net/browse/NT-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ